### PR TITLE
fix[close #59]: Creating subsystem does not show anything and just freezes 

### DIFF
--- a/apx_gui/gtk/tab-subsystem.ui
+++ b/apx_gui/gtk/tab-subsystem.ui
@@ -58,10 +58,10 @@
 							<object class="AdwPreferencesGroup">
 								<property name="title" translatable="yes">Subsystem actions</property>
 								<child>
-									<object class="AdwActionRow" id="row_startstop">
-										<property name="activatable-widget">btn_startstop</property>
+									<object class="AdwActionRow" id="row_start_stop">
+										<property name="activatable-widget">btn_start_stop</property>
 										<child type="suffix">
-											<object class="GtkButton" id="btn_startstop">
+											<object class="GtkButton" id="btn_start_stop">
 												<property name="valign">center</property>
 												<style>
 													<class name="flat"/>

--- a/apx_gui/widgets/entry_subsystem.py
+++ b/apx_gui/widgets/entry_subsystem.py
@@ -17,7 +17,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from gi.repository import Gtk, Adw
+from gi.repository import Gtk, Adw  # pyright: ignore
 from uuid import UUID
 
 from gettext import gettext as _

--- a/apx_gui/widgets/tab_subsystem.py
+++ b/apx_gui/widgets/tab_subsystem.py
@@ -17,7 +17,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from gi.repository import Gtk, Gdk, GLib, Adw, Vte
+from gi.repository import Gtk, Gdk, GLib, Adw, Vte  # pyright: ignore
 from uuid import UUID
 
 from gettext import gettext as _
@@ -39,10 +39,10 @@ class TabSubsystem(Gtk.Box):
     row_stack: Adw.ActionRow = Gtk.Template.Child()  # pyright: ignore
     row_pkgmanager: Adw.ActionRow = Gtk.Template.Child()  # pyright: ignore
     row_programs: Adw.ExpanderRow = Gtk.Template.Child()  # pyright: ignore
-    row_startstop: Adw.ActionRow = Gtk.Template.Child()  # pyright: ignore
+    row_start_stop: Adw.ActionRow = Gtk.Template.Child()  # pyright: ignore
     row_reset: Adw.ActionRow = Gtk.Template.Child()  # pyright: ignore
     row_delete: Adw.ActionRow = Gtk.Template.Child()  # pyright: ignore
-    btn_startstop: Gtk.Button = Gtk.Template.Child()  # pyright: ignore
+    btn_start_stop: Gtk.Button = Gtk.Template.Child()  # pyright: ignore
     btn_autoremove: Gtk.Button = Gtk.Template.Child()  # pyright: ignore
     btn_clean: Gtk.Button = Gtk.Template.Child()  # pyright: ignore
     btn_toggle_console: Gtk.Button = Gtk.Template.Child()  # pyright: ignore
@@ -62,7 +62,7 @@ class TabSubsystem(Gtk.Box):
         self.__aid: UUID = subsystem.aid
         self.__subsystem: Subsystem = subsystem
 
-        self.btn_startstop.connect("clicked", self.__on_startstop_clicked)
+        self.btn_start_stop.connect("clicked", self.__on_start_stop_clicked)
         self.btn_autoremove.connect("clicked", self.__on_autoremove_clicked)
         self.btn_clean.connect("clicked", self.__on_clean_clicked)
 
@@ -92,11 +92,11 @@ class TabSubsystem(Gtk.Box):
         )
 
         if self.subsystem.running:
-            self.row_startstop.set_title(_("Stop subsystem"))
-            self.btn_startstop.set_icon_name("media-playback-stop-symbolic")
+            self.row_start_stop.set_title(_("Stop subsystem"))
+            self.btn_start_stop.set_icon_name("media-playback-stop-symbolic")
         else:
-            self.row_startstop.set_title(_("Start subsystem"))
-            self.btn_startstop.set_icon_name("media-playback-start-symbolic")
+            self.row_start_stop.set_title(_("Start subsystem"))
+            self.btn_start_stop.set_icon_name("media-playback-start-symbolic")
 
     def __create_console(self) -> Vte.Terminal:
         console: Vte.Terminal = Vte.Terminal()
@@ -211,7 +211,7 @@ class TabSubsystem(Gtk.Box):
         dialog.connect("response", on_response)
         dialog.present()
 
-    def __on_startstop_clicked(self, button: Gtk.Button) -> None:
+    def __on_start_stop_clicked(self, button: Gtk.Button) -> None:
         def on_response(dialog: Adw.MessageDialog, response: str) -> None:
             if response == "ok":
                 self.__window.toast(


### PR DESCRIPTION
At first glance, I found this looks like just a typo:

![image](https://github.com/Vanilla-OS/apx-gui/assets/9479903/d02f5ddb-4421-45fd-b991-ccc011aa9a38)

but after further investigation, I found more issues, like:
- the new Subsystem object's enter_command variable not getting populated, making the console unusable
- the Subsystem's create function not properly handle arguments when apx-gui is running inside a container
- the result of the creation, not being used at all, making the error dialog never appear if anything goes wrong

plus some minor issues in typing:
- run_vte_command was declaring the return as a tuple of a bool and string, but nothing was getting returned, anyway I changed it to just a bool and implemented it using the Vte.spawn_sync result
- __on_create_clicked had an inherit create_subsystem method for no reason, we are not inside an async method here, Vte is handling it for us, no need to have a second function
- the NewSubsystem variable should follow the snake case formato, so I renamed it to new_subsystem, same for btn_startstop that is now btn_start_stop

I also added some prints in the subsystem creation process so a users can provide the command used to create the subsystem, as long as the output and result for the creation itself.