### PR TITLE
fix: reduce noise in process output

### DIFF
--- a/apx_gui/core/monitor.py
+++ b/apx_gui/core/monitor.py
@@ -104,9 +104,13 @@ class Monitor:
 
         session = requests.Session()
         session.mount("http://localhost/", SocketAdapter(socket_path))
-        response = session.get(
-            f"http://localhost/events?since={Monitor.__last_read}&stream=false"
-        )
+        try:
+            response = session.get(
+                f"http://localhost/events?since={Monitor.__last_read}&stream=false"
+            )
+        except Exception as err:
+            print(err)
+            return
         response.raise_for_status()
 
         events = []

--- a/apx_gui/windows/main_window.py
+++ b/apx_gui/windows/main_window.py
@@ -67,17 +67,20 @@ class ApxGUIWindow(Adw.ApplicationWindow):
 
     def __read_changes(self) -> bool:
         def callback(events: list[dict[str, Any]], exception: Exception):
-            for event in events:
-                for subsystem in self.__subsystems:
-                    if event["Actor"]["Attributes"]["name"] == "apx-" + subsystem.name:
-                        if event["status"] == "start":
-                            subsystem.status = "Up"
-                        elif event["status"] == "die":
-                            subsystem.status = "Exited"
+            try:
+                for event in events:
+                    for subsystem in self.__subsystems:
+                        if event["Actor"]["Attributes"]["name"] == "apx-" + subsystem.name:
+                            if event["status"] == "start":
+                                subsystem.status = "Up"
+                            elif event["status"] == "die":
+                                subsystem.status = "Exited"
 
-                        self.sidebar.update_subsystem(subsystem)
-                        self.editor.update_subsystem_tab(subsystem)
-                        break
+                            self.sidebar.update_subsystem(subsystem)
+                            self.editor.update_subsystem_tab(subsystem)
+                            break
+            except TypeError:
+                print("No new events queue.  Skipping UI refresh...")
 
         RunAsync(Monitor.read, callback)
         return True


### PR DESCRIPTION
- handle Nonetype when no events are read in callback
- remove stacktrace from url request in monitor

This changes the standard output cycle from:
```
ERROR:Vanilla::Async:Error while running async job: <function Monitor.read at 0x7f2bc4742ca0>
Exception: HTTPConnectionPool(host='localhost', port=80): Max retries exceeded with url: /events?since=2024-10-19T23:55:22&stream=false (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f2baff42690>: Failed to establish a new connection: [Errno 111] Connection refused'))
  File "/home/jardon/.local/share/apx_gui/apx_gui/core/run_async.py", line 73, in __target
    result = self.task_func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jardon/.local/share/apx_gui/apx_gui/core/monitor.py", line 107, in read
    response = session.get(
               ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 602, in get
    return self.request("GET", url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/requests/adapters.py", line 700, in send
    raise ConnectionError(e, request=request)
Traceback (most recent call last):
  File "/home/jardon/.local/share/apx_gui/apx_gui/windows/main_window.py", line 70, in callback
    for event in events:
                 ^^^^^^
TypeError: 'NoneType' object is not iterable
```
to:
```
HTTPConnectionPool(host='localhost', port=80): Max retries exceeded with url: /events?since=2024-10-20T12:25:51&stream=false (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7facac9f4a40>: Failed to establish a new connection: [Errno 111] Connection refused'))
No new events queue.  Skipping UI refresh...
```
its a small thing that helps with debugging