### PR TITLE
fix [#88]: shows window buttons on the left

### DIFF
--- a/apx_gui/gtk/sidebar.ui
+++ b/apx_gui/gtk/sidebar.ui
@@ -19,7 +19,6 @@
           <object class="AdwHeaderBar">
             <property name="margin-top">5</property>
             <property name="show-end-title-buttons">false</property>
-            <property name="show-start-title-buttons">false</property>
             <property name="title-widget">
               <object class="AdwViewSwitcher">
                 <property name="stack">stack_sidebar</property>


### PR DESCRIPTION
The window buttons (like the close button) were completely missing when on the right.

closes #88