### PR TITLE
fix: [#92] recursively remove GTKLabels for AdwViewSwitcher

### DIFF
--- a/apx_gui/gtk/sidebar.ui
+++ b/apx_gui/gtk/sidebar.ui
@@ -20,7 +20,7 @@
             <property name="margin-top">5</property>
             <property name="show-end-title-buttons">false</property>
             <property name="title-widget">
-              <object class="AdwViewSwitcher">
+              <object class="AdwViewSwitcher" id="sidebar_switcher">
                 <property name="stack">stack_sidebar</property>
                 <property name="policy">1</property>
               </object>

--- a/apx_gui/widgets/sidebar.py
+++ b/apx_gui/widgets/sidebar.py
@@ -41,6 +41,7 @@ class Sidebar(Adw.Bin):
     list_pkgmanagers: Gtk.ListBox = Gtk.Template.Child()  # pyright: ignore
     stack_sidebar: Adw.ViewStack = Gtk.Template.Child()  # pyright: ignore
     btn_new: Adw.SplitButton = Gtk.Template.Child()  # pyright: ignore
+    sidebar_switcher: Adw.ViewSwitcher = Gtk.Template.Child() # pyright: ignore
 
     def __init__(
         self,
@@ -63,6 +64,8 @@ class Sidebar(Adw.Bin):
         self.list_pkgmanagers.connect("row-selected", self.__on_pkgmanager_selected)
 
         self.btn_new.connect("clicked", self.__on_btn_menu_clicked)
+
+        self.hide_labels(self.sidebar_switcher)
 
         for subsystem in self.__subsystems:
             entry = EntrySubsystem(subsystem)
@@ -161,3 +164,12 @@ class Sidebar(Adw.Bin):
             idx += 1
 
         self.__registry__[str(subsystem.aid)] = new_entry
+
+    def hide_labels(self, widget):
+        if isinstance(widget, Gtk.Label):
+            widget.set_visible(False)
+        elif isinstance(widget, Gtk.Widget):
+            child = widget.get_first_child()
+            while child:
+                self.hide_labels(child)
+                child = child.get_next_sibling()


### PR DESCRIPTION
this is not directly fixable as the gtklabel thats created by the adwstackspage are not addressable.  the labels have no title text, but they still take up space causing the icons to be misaligned.  this change passes the parent adwviewswticher into a recursive function that checks all children for being a gtklabel type and sets the visibility to false.

its a dumb workaround, but from what i understand, its one of the only ways to do it.

closes #92 